### PR TITLE
Videreutvikling ettersendelse

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,23 @@
+name: "Test"
+on: push
+
+jobs:
+  test:
+    name: "Test"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: "16.17.1"
+      - name: "install dependencies"
+        run: yarn install --frozen-lockfile
+      - name: "Build application"
+        run: yarn build:mock
+      - name: "Cypress tests"
+        uses: cypress-io/github-action@v4
+        with:
+          install: false
+          start: "yarn run start:mock"
+          wait-on: "http://localhost:3002/fyllut-ettersending, http://localhost:3002/fyllut-ettersending/api/internal/isready"
+          config-file: "cypress.config.ts"

--- a/cypress/e2e/axe.spec.cy.ts
+++ b/cypress/e2e/axe.spec.cy.ts
@@ -7,7 +7,7 @@ describe("Axe testing for main page", () => {
   it("tests axe for the entire website", () => {
     cy.findByRole("main").should("exist");
     cy.checkA11y(".main");
-    cy.get("[type=\"radio\"]").eq(1).check();
+    cy.contains("button", "Annen dokumentasjon").click()
     cy.get("[name=\"otherDocumentationTitle\"]").click().type("Application for parental leave");
     cy.findByRole("main").should("exist");
     cy.checkA11y(".main");

--- a/cypress/e2e/reset.spec.cy.ts
+++ b/cypress/e2e/reset.spec.cy.ts
@@ -21,7 +21,7 @@ describe("reset", () => {
     // Gå tilbake
     cy.findAllByRole("link").eq(0).click();
 
-    // Skriv inn "form2" i tekstboksen
+    // Skriv inn "hund" i tekstboksen
     cy.findAllByRole("textbox").click().type("hund");
 
     // Klikk det andre skjemaet

--- a/cypress/e2e/reset.spec.cy.ts
+++ b/cypress/e2e/reset.spec.cy.ts
@@ -1,25 +1,39 @@
 describe("reset", () => {
   before(() => {
     cy.intercept("GET", `${Cypress.config("baseUrl")}/api/forms`).as("getForms");
-    cy.intercept("GET", `${Cypress.config("baseUrl")}/api/archive-subjects`).as("getArchiveSubjects");
-    cy.intercept("GET", `${Cypress.config("baseUrl")}/api/nav-units`).as("getNavUnits");
-    cy.visit("/");
+    cy.visit("/ettersendelse");
     cy.wait("@getForms");
-    cy.wait("@getArchiveSubjects");
-    cy.wait("@getNavUnits");
   });
 
   it("resets formData when a different form is selected than the one previously selected", () => {
-    cy.findAllByRole("radio").eq(0).check();
+    // Skriv inn "test" i tekstboksen
     cy.findAllByRole("textbox").focus().type("test");
+
+    // Klikk det første skjemaet
     cy.findAllByRole("link").eq(1).click();
+
+    // Sjekk at URLen inneholder "/detaljer"
     cy.url().should("include", "/detaljer");
+
+    // Sjekk av checboxen
     cy.findAllByRole("checkbox").first().check();
-    cy.findByRole("link").click();
-    cy.findAllByRole("textbox").click().type("form2");
+
+    // Gå tilbake
+    cy.findAllByRole("link").eq(0).click();
+
+    // Skriv inn "form2" i tekstboksen
+    cy.findAllByRole("textbox").click().type("hund");
+
+    // Klikk det andre skjemaet
     cy.findAllByRole("link").eq(1).click();
+
+    // Sjekk at URLen inneholder "/detaljer"
     cy.url().should("include", "/detaljer");
+
+    // Sjekk at checkboxen ikke er sjekket
     cy.findAllByRole("checkbox").should("not.be.checked");
+
+    // Sjekk at ingen av checkboxene er sjekket (formet er resatt)
     cy.findAllByRole("checkbox").each(($el) => {
       cy.wrap($el).should("have.not.attr", "checked");
     });

--- a/cypress/e2e/sendAnotherDocument.spec.cy.ts
+++ b/cypress/e2e/sendAnotherDocument.spec.cy.ts
@@ -1,17 +1,14 @@
 describe("sendAnotherDocument", () => {
   before(() => {
-    cy.intercept("GET", `${Cypress.config("baseUrl")}/api/forms`).as("getForms");
     cy.intercept("GET", `${Cypress.config("baseUrl")}/api/archive-subjects`).as("getArchiveSubjects");
     cy.intercept("GET", `${Cypress.config("baseUrl")}/api/nav-units`).as("getNavUnits");
-    cy.visit("/");
-    cy.wait("@getForms");
+    cy.visit("/lospost");
     cy.wait("@getArchiveSubjects");
     cy.wait("@getNavUnits");
   });
 
   it("send another document", () => {
     //Populate velg skjema page
-    cy.findAllByRole("radio").eq(1).check();
     cy.get("[name=\"otherDocumentationTitle\"]").click().type("Application for parental leave");
     cy.get("[name=\"subjectOfSubmission\"]").select("Permittering og masseoppsigelser");
     cy.findAllByRole("radio").check("noSocialNumber");

--- a/cypress/e2e/sendPreviouslySubmittedApplication.spec.cy.ts
+++ b/cypress/e2e/sendPreviouslySubmittedApplication.spec.cy.ts
@@ -1,16 +1,11 @@
 describe.only("sendPreviouslySubmittedApplication", () => {
   before(() => {
     cy.intercept("GET", `${Cypress.config("baseUrl")}/api/forms`).as("getForms");
-    cy.intercept("GET", `${Cypress.config("baseUrl")}/api/archive-subjects`).as("getArchiveSubjects");
-    cy.intercept("GET", `${Cypress.config("baseUrl")}/api/nav-units`).as("getNavUnits");
-    cy.visit("/");
+    cy.visit("/ettersendelse");
     cy.wait("@getForms");
-    cy.wait("@getArchiveSubjects");
-    cy.wait("@getNavUnits");
   });
 
   it("fill out send documentation", () => {
-    cy.findAllByRole("radio").eq(0).check();
     cy.get("[name=\"search\"]").click().type("førerhund");
     cy.findAllByRole("link").eq(1).click();
     cy.url().should("include", "/detaljer");

--- a/src/api/apiService.ts
+++ b/src/api/apiService.ts
@@ -51,6 +51,7 @@ const getForm = async (formPath: string): Promise<Form | undefined> => {
       submissionType: form?.properties.innsending ?? null,
       navUnitTypes: form?.properties.enhetstyper ?? [],
       subjectOfSubmission: form?.properties.tema ?? null,
+      navUnitMustBeSelected: form?.properties.enhetMaVelgesVedPapirInnsending ?? null,
     },
   };
 };

--- a/src/api/frontPageService.ts
+++ b/src/api/frontPageService.ts
@@ -84,9 +84,15 @@ interface FrontPageRequest {
   adresse?: FrontPageAddress;
   bruker?: FrontPageUser;
   ukjentBrukerPersoninfo?: string;
+  tittel?: string;
+  behandlingstema?: string;
+  "NAV-skjemaID"?: string;
+  enhetsnummer?: string;
+  avsender?: FrontPageSender;
+  arkivsak?: FrontPageArchiveCase
 }
 
-type FrontPageType = "SKJEMA" | "ETTERSENDELSE";
+type FrontPageType = "SKJEMA" | "ETTERSENDELSE" | "LOESPOST";
 
 export interface FrontPageAddress {
   adresselinje1: string;
@@ -99,6 +105,16 @@ export interface FrontPageAddress {
 interface FrontPageUser {
   brukerId: string;
   brukerType: string;
+}
+
+interface FrontPageSender {
+  avsenderID: string;
+  avsenderNavn: string;
+}
+
+interface FrontPageArchiveCase {
+  arkivsaksystem: string;
+  arkivsaksnummer: string;
 }
 
 export { download };

--- a/src/api/frontPageService.ts
+++ b/src/api/frontPageService.ts
@@ -32,7 +32,7 @@ const getTitle = (formData: FormData) => {
   if (formData.formNumber) {
     return `Ettersendelse til ${formData.formNumber} ${formData.title} - ${formData.otherDocumentationTitle}`;
   } else {
-    return `Innsendelsen gjelder: ${formData.subjectOfSubmission}`;
+    return `Innsendelsen gjelder: ${formData.titleOfSubmission} - ${formData.otherDocumentationTitle}`;
   }
 };
 

--- a/src/api/frontPageService.ts
+++ b/src/api/frontPageService.ts
@@ -29,10 +29,11 @@ const toFrontPageRequest = (formData: FormData): FrontPageRequest => {
 };
 
 const getTitle = (formData: FormData) => {
+  const otherDocumentationTitle = formData.otherDocumentationTitle ? ` - ${formData.otherDocumentationTitle}` : "";
   if (formData.formNumber) {
-    return `Ettersendelse til ${formData.formNumber} ${formData.title} - ${formData.otherDocumentationTitle}`;
+    return `Ettersendelse til ${formData.formNumber} ${formData.title}` + otherDocumentationTitle;
   } else {
-    return `Innsendelsen gjelder: ${formData.titleOfSubmission} - ${formData.otherDocumentationTitle}`;
+    return `Innsendelsen gjelder: ${formData.titleOfSubmission}` + otherDocumentationTitle;
   }
 };
 

--- a/src/api/frontPageService.ts
+++ b/src/api/frontPageService.ts
@@ -30,7 +30,7 @@ const toFrontPageRequest = (formData: FormData): FrontPageRequest => {
 
 const getTitle = (formData: FormData) => {
   if (formData.formNumber) {
-    return `Ettersendelse til ${formData.formNumber} ${formData.title}`;
+    return `Ettersendelse til ${formData.formNumber} ${formData.title} - ${formData.otherDocumentationTitle}`;
   } else {
     return `Innsendelsen gjelder: ${formData.subjectOfSubmission}`;
   }

--- a/src/components/search/formSearch.tsx
+++ b/src/components/search/formSearch.tsx
@@ -26,6 +26,10 @@ const FormSearch = ({ forms }: Props) => {
     setSearchResult(result);
   }, [searchInput, forms]);
 
+  const sortForms = (a: Form, b: Form) => {
+    return a.title.trim().localeCompare(b.title.trim());
+  };
+
   return (
     <>
       <Section>
@@ -42,21 +46,23 @@ const FormSearch = ({ forms }: Props) => {
       </Section>
 
       <div className={styles.results}>
-        {searchResult.sort((a,b) => a.title.trim().localeCompare(b.title.trim())).map((form, index) => (
-          <LinkPanel
-            href="#"
-            className={styles.clickable}
-            key={index}
-            border
-            onClick={async (e) => {
-              e.preventDefault();
-              await router.push(`${Paths.details}/${form.path}`);
-            }}
-          >
-            <LinkPanel.Title>{form.title}</LinkPanel.Title>
-            <LinkPanel.Description>{form.properties?.skjemanummer}</LinkPanel.Description>
-          </LinkPanel>
-        ))}
+        {searchResult
+          .sort((a, b) => sortForms(a, b))
+          .map((form, index) => (
+            <LinkPanel
+              href="#"
+              className={styles.clickable}
+              key={index}
+              border
+              onClick={async (e) => {
+                e.preventDefault();
+                await router.push(`${Paths.details}/${form.path}`);
+              }}
+            >
+              <LinkPanel.Title>{form.title}</LinkPanel.Title>
+              <LinkPanel.Description>{form.properties?.skjemanummer}</LinkPanel.Description>
+            </LinkPanel>
+          ))}
       </div>
     </>
   );

--- a/src/components/search/formSearch.tsx
+++ b/src/components/search/formSearch.tsx
@@ -42,7 +42,7 @@ const FormSearch = ({ forms }: Props) => {
       </Section>
 
       <div className={styles.results}>
-        {searchResult.map((form, index) => (
+        {searchResult.sort((a,b) => a.title.trim().localeCompare(b.title.trim())).map((form, index) => (
           <LinkPanel
             href="#"
             className={styles.clickable}

--- a/src/components/submission/chooseUser.tsx
+++ b/src/components/submission/chooseUser.tsx
@@ -7,9 +7,10 @@ import ContactInformation from "./contactInformation";
 
 interface Props {
   navUnits?: NavUnit[] | undefined;
+  shouldRenderNavUnits?: boolean;
 }
 
-const ChooseUser = ({ navUnits }: Props) => {
+const ChooseUser = ({ navUnits, shouldRenderNavUnits = true }: Props) => {
   const { formData, updateFormData, updateUserData, errors } = useFormState();
 
   return (
@@ -35,9 +36,11 @@ const ChooseUser = ({ navUnits }: Props) => {
           <Radio name={UserType.noSocialNumber} value={UserType.noSocialNumber}>
             En person som ikke har fødselsnummer eller D-nummer
           </Radio>
-          <Radio name={UserType.other} value={UserType.other}>
-            Flere personer samtidig eller tiltaksbedrifter, kursarrangører og andre virksomheter
-          </Radio>
+          {shouldRenderNavUnits && (
+            <Radio name={UserType.other} value={UserType.other}>
+              Flere personer samtidig eller tiltaksbedrifter, kursarrangører og andre virksomheter
+            </Radio>
+          )}
         </RadioGroup>
       </Section>
 

--- a/src/components/submission/subjectOfSubmission.tsx
+++ b/src/components/submission/subjectOfSubmission.tsx
@@ -32,7 +32,10 @@ const SubjectOfSubmission = ({ archiveSubjects }: Props) => {
           value={formData.subjectOfSubmission}
           error={errors.subjectOfSubmission}
           onChange={(evt) => {
-            updateFormData({ subjectOfSubmission: evt.target.value });
+            updateFormData({
+              subjectOfSubmission: evt.target.value,
+              titleOfSubmission: archiveSubjects[evt.target.value],
+            });
           }}
         >
           <option></option>

--- a/src/data/domain.ts
+++ b/src/data/domain.ts
@@ -21,6 +21,7 @@ interface FormProperties {
   skjemanummer?: string;
   submissionType?: string;
   navUnitTypes?: string[];
+  navUnitMustBeSelected?: boolean;
   subjectOfSubmission?: string;
 }
 

--- a/src/data/domain.ts
+++ b/src/data/domain.ts
@@ -42,6 +42,7 @@ interface FormData {
   formNumber?: string;
   otherDocumentationTitle?: string;
   subjectOfSubmission?: string;
+  titleOfSubmission?: string;
   title?: string;
   userData?: UserData;
 }

--- a/src/data/text.ts
+++ b/src/data/text.ts
@@ -1,6 +1,8 @@
 enum ButtonText {
   next = "Neste",
   cancel = "Avbryt",
+  sendAttachment = "Ettersend vedlegg",
+  otherDocumentation = "Annen dokumentasjon",
 }
 
 const ErrorMessages = {
@@ -26,6 +28,8 @@ enum Paths {
   base = "/",
   details = "/detaljer",
   downloadPage = "/last-ned",
+  otherDocumentation = "/lospost",
+  formDocumentation = "/ettersendelse"
 }
 
 export { Paths, ButtonText, ErrorMessages };

--- a/src/pages/detaljer/[id].tsx
+++ b/src/pages/detaljer/[id].tsx
@@ -73,7 +73,10 @@ const Detaljer: NextPage<Props> = (props) => {
         <>
           <ChooseAttachments form={form} />
 
-          <ChooseUser navUnits={getNavUnitsConnectedToForm(form.properties.navUnitTypes)} />
+          <ChooseUser
+            navUnits={getNavUnitsConnectedToForm(form.properties.navUnitTypes)}
+            shouldRenderNavUnits={form.properties.navUnitMustBeSelected}
+          />
 
           <ButtonGroup
             buttons={[

--- a/src/pages/detaljer/[id].tsx
+++ b/src/pages/detaljer/[id].tsx
@@ -31,7 +31,9 @@ const Detaljer: NextPage<Props> = (props) => {
   }, []);
 
   useEffect(() => {
-    fetchData();
+    if (form.properties.navUnitMustBeSelected) {
+      fetchData();
+    }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [id]);
 

--- a/src/pages/ettersendelse.tsx
+++ b/src/pages/ettersendelse.tsx
@@ -1,0 +1,42 @@
+import "@navikt/ds-css";
+import { Loader } from "@navikt/ds-react";
+import type { NextPage } from "next";
+import { useCallback, useEffect, useState } from "react";
+import { Form } from "../data/domain";
+import FormSearch from "../components/search/formSearch";
+import Layout from "../components/layout/layout";
+import { fetchForms } from "../api/apiClient";
+
+interface Props {
+  forms: Form[];
+}
+
+const Ettersendelse: NextPage<Props> = () => {
+  const [loading, setLoading] = useState<boolean>(true);
+  const [forms, setForms] = useState<Form[]>([]);
+
+  const fetchData = useCallback(async () => {
+    const [formsResponse] = await Promise.all([fetchForms()]);
+    setForms(formsResponse);
+    setLoading(false);
+  }, []);
+
+  useEffect(() => {
+    fetchData();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  return (
+    <Layout title="Ettersende dokumentasjon">
+      {loading ? (
+        <div className="loader">
+          <Loader size="xlarge" title="Henter data..." />
+        </div>
+      ) : (
+        <FormSearch forms={forms} />
+      )}
+    </Layout>
+  );
+};
+
+export default Ettersendelse;

--- a/src/pages/ettersendelse.tsx
+++ b/src/pages/ettersendelse.tsx
@@ -7,9 +7,7 @@ import FormSearch from "../components/search/formSearch";
 import Layout from "../components/layout/layout";
 import { fetchForms } from "../api/apiClient";
 
-interface Props {
-  forms: Form[];
-}
+interface Props {}
 
 const Ettersendelse: NextPage<Props> = () => {
   const [loading, setLoading] = useState<boolean>(true);

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,90 +1,43 @@
 import "@navikt/ds-css";
-import { Loader, Radio, RadioGroup } from "@navikt/ds-react";
+import { Button, Heading, BodyShort } from "@navikt/ds-react";
 import type { NextPage } from "next";
-import { useCallback, useEffect, useState } from "react";
-import { Form, KeyValue, NavUnit } from "../data/domain";
-import FormSearch from "../components/search/formSearch";
-import { useFormState } from "../data/appState";
 import Section from "../components/section/section";
 import Layout from "../components/layout/layout";
-import OtherDocument from "../components/other-document/other-document";
-import { fetchArchiveSubjects, fetchForms, fetchNavUnits } from "../api/apiClient";
+import { useRouter } from "next/router";
+import { Paths } from "../data/text";
 
-interface Props {
-  forms: Form[];
-  archiveSubjects: KeyValue;
-  navUnits: NavUnit[];
-}
-
-enum SubmissionType {
-  documentationToForm = "documentationToForm",
-  otherDocumentation = "otherDocumentation",
-}
+interface Props {}
 
 const Home: NextPage<Props> = () => {
-  const [loading, setLoading] = useState<boolean>(true);
-  const [submissionType, setSubmissionType] = useState<SubmissionType>();
-  const [forms, setForms] = useState<Form[]>([]);
-  const [archiveSubjects, setArchiveSubjects] = useState<KeyValue>({});
-  const [navUnits, setNavUnits] = useState<NavUnit[]>([]);
-  const { resetFormData, formData } = useFormState();
+  const router = useRouter();
 
-  const fetchData = useCallback(async () => {
-    const [formsResponse, archiveSubjectsResponse, navUnitsResponse] = await Promise.all([
-      fetchForms(),
-      fetchArchiveSubjects(),
-      fetchNavUnits(),
-    ]);
-    setForms(formsResponse);
-    setArchiveSubjects(archiveSubjectsResponse);
-    setNavUnits(navUnitsResponse);
-    setLoading(false);
-  }, []);
-
-  useEffect(() => {
-    fetchData();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
-
-  useEffect(() => {
-    if (formData.formId) {
-      resetFormData();
-      setSubmissionType(SubmissionType.documentationToForm);
-    } else if (Object.keys(formData).length !== 0) {
-      setSubmissionType(SubmissionType.otherDocumentation);
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [formData.formId]);
+  const handleClick = async (path: string) => {
+    await router.push(path);
+  };
 
   return (
     <Layout title="Sende inn dokumentasjon">
-      <Section>
-        <RadioGroup
-          legend="Hva gjelder innsendingen?"
-          size="medium"
-          onChange={(value) => setSubmissionType(value)}
-          value={submissionType ?? ""}
-        >
-          <Radio name={SubmissionType.documentationToForm} value={SubmissionType.documentationToForm}>
-            Jeg skal ettersende vedlegg til en tidligere innsendt søknad
-          </Radio>
-          <Radio name={SubmissionType.otherDocumentation} value={SubmissionType.otherDocumentation}>
-            Jeg skal sende annen dokumentasjon til NAV
-          </Radio>
-        </RadioGroup>
-      </Section>
-      {submissionType === SubmissionType.documentationToForm &&
-        (loading ? (
-          <div className="loader">
-            <Loader size="xlarge" title="Henter data..." />
-          </div>
-        ) : (
-          <FormSearch forms={forms} />
-        ))}
+      <Heading size="large" spacing={true}>
+        Hva gjelder innsendingen?
+      </Heading>
 
-      {submissionType === SubmissionType.otherDocumentation && (
-        <OtherDocument archiveSubjects={archiveSubjects} navUnits={navUnits} />
-      )}
+      <Section>
+        <BodyShort spacing={true}>
+          Velg “Ettersend vedlegg” hvis du skal ettersende dokumentasjon til en søknad du har sendt tidligere.
+        </BodyShort>
+        <Button variant="primary" onClick={() => handleClick(Paths.formDocumentation)}>
+          Ettersend vedlegg
+        </Button>
+      </Section>
+
+      <Section>
+        <BodyShort spacing={true}>
+          Velg “Annen dokumentasjon“ hvis du vil sende dokumentasjon som ikke er knyttet til en søknad.
+        </BodyShort>
+        <Button variant="primary" onClick={() => handleClick(Paths.otherDocumentation)}>
+          Annen dokumentasjon
+        </Button>
+      </Section>
     </Layout>
   );
 };

--- a/src/pages/lospost.tsx
+++ b/src/pages/lospost.tsx
@@ -6,10 +6,7 @@ import Layout from "../components/layout/layout";
 import OtherDocument from "../components/other-document/other-document";
 import { fetchArchiveSubjects, fetchNavUnits } from "../api/apiClient";
 
-interface Props {
-  archiveSubjects: KeyValue;
-  navUnits: NavUnit[];
-}
+interface Props {}
 
 const Lospost: NextPage<Props> = () => {
   const [archiveSubjects, setArchiveSubjects] = useState<KeyValue>({});

--- a/src/pages/lospost.tsx
+++ b/src/pages/lospost.tsx
@@ -1,0 +1,36 @@
+import "@navikt/ds-css";
+import type { NextPage } from "next";
+import { useCallback, useEffect, useState } from "react";
+import { KeyValue, NavUnit } from "../data/domain";
+import Layout from "../components/layout/layout";
+import OtherDocument from "../components/other-document/other-document";
+import { fetchArchiveSubjects, fetchNavUnits } from "../api/apiClient";
+
+interface Props {
+  archiveSubjects: KeyValue;
+  navUnits: NavUnit[];
+}
+
+const Lospost: NextPage<Props> = () => {
+  const [archiveSubjects, setArchiveSubjects] = useState<KeyValue>({});
+  const [navUnits, setNavUnits] = useState<NavUnit[]>([]);
+
+  const fetchData = useCallback(async () => {
+    const [archiveSubjectsResponse, navUnitsResponse] = await Promise.all([fetchArchiveSubjects(), fetchNavUnits()]);
+    setArchiveSubjects(archiveSubjectsResponse);
+    setNavUnits(navUnitsResponse);
+  }, []);
+
+  useEffect(() => {
+    fetchData();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  return (
+    <Layout title="Sende inn dokumentasjon">
+      <OtherDocument archiveSubjects={archiveSubjects} navUnits={navUnits} />
+    </Layout>
+  );
+};
+
+export default Lospost;


### PR DESCRIPTION
## Beskrivelse

Videreutvikling av ettersendelsestjenesten med litt forbedringer: 

- Sortering av skjemaer
- Tittel på dokumentet inneholder nå tema (fulltekst, ikke TBF)  + navn på dokumentet bruker skriver inn:
![Skjermbilde 2023-04-18 kl  09 42 50](https://user-images.githubusercontent.com/7783861/232707114-ace4e8c0-50aa-4d65-8fb5-c1bf7fc3a4fc.png)
- Ettersendelse og løspost er separert inn i to sider. Hovedssiden ser slik ut med linker til begge undersidene:
![Skjermbilde 2023-04-18 kl  09 40 15](https://user-images.githubusercontent.com/7783861/232707359-2e308243-a0df-4b86-be71-9d9bf60cb048.png)

