### PR TITLE
Bugfix for attachment selection

### DIFF
--- a/cypress/e2e/reset.spec.cy.ts
+++ b/cypress/e2e/reset.spec.cy.ts
@@ -5,7 +5,6 @@ describe("reset", () => {
     cy.wait("@getForms");
   });
 
-  // TODO: This test fails due to a known bug (https://trello.com/c/aLlQ7Ntf/1308-valg-av)
   it("resets formData when a different form is selected than the one previously selected", () => {
     // Skriv inn "test" i tekstboksen
     cy.findAllByRole("textbox").focus().type("test");

--- a/cypress/e2e/reset.spec.cy.ts
+++ b/cypress/e2e/reset.spec.cy.ts
@@ -6,7 +6,7 @@ describe("reset", () => {
   });
 
   // TODO: This test fails due to a known bug (https://trello.com/c/aLlQ7Ntf/1308-valg-av)
-  it.skip("resets formData when a different form is selected than the one previously selected", () => {
+  it("resets formData when a different form is selected than the one previously selected", () => {
     // Skriv inn "test" i tekstboksen
     cy.findAllByRole("textbox").focus().type("test");
 
@@ -26,7 +26,7 @@ describe("reset", () => {
     cy.findAllByRole("textbox").click().type("hund");
 
     // Klikk det andre skjemaet
-    cy.get('[data-cy="searchResults"]').findAllByRole("link").eq(1).click();
+    cy.get('[data-cy="searchResults"]').findAllByRole("link").eq(0).click();
 
     // Sjekk at URLen inneholder "/detaljer"
     cy.url().should("include", "/detaljer");

--- a/cypress/e2e/sendPreviouslySubmittedApplication.spec.cy.ts
+++ b/cypress/e2e/sendPreviouslySubmittedApplication.spec.cy.ts
@@ -29,6 +29,6 @@ describe.only("sendPreviouslySubmittedApplication", () => {
     cy.get("button").contains(ButtonText.next).click();
     cy.url().should("include", "/sendinn/opprettSoknadResource?erEttersendelse=true");
     cy.url({ decode: true }).should("include", "skjemanummer=NAV 10-07.50");
-    cy.url().should("include", "vedleggsIder=L9,N6");
+    cy.url().should("include", "vedleggsIder=N6,L9");
   });
 });

--- a/src/components/attachment/chooseAttachments.tsx
+++ b/src/components/attachment/chooseAttachments.tsx
@@ -4,7 +4,6 @@ import Section from "../section/section";
 import styles from "../attachment/attachment.module.css";
 import { useFormState } from "../../data/appState";
 import { hasOtherAttachment } from "../../utils/formDataUtil";
-import { useEffect, useState } from "react";
 import { isSubmissionTypeByMail } from "../../utils/submissionUtil";
 
 interface Props {
@@ -13,15 +12,6 @@ interface Props {
 
 const ChooseAttachments = ({ form }: Props) => {
   const { formData, updateFormData, errors } = useFormState();
-  const [attachmentKeys, setAttachmentKeys] = useState<string[]>([]);
-
-  useEffect(() => {
-    const formAttachmentKeys = formData.attachments?.map((attachment) => attachment.key);
-    if (formAttachmentKeys && formAttachmentKeys.length > 0) {
-      setAttachmentKeys(formAttachmentKeys);
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
 
   return (
     <>
@@ -29,25 +19,16 @@ const ChooseAttachments = ({ form }: Props) => {
         <Section>
           <CheckboxGroup
             legend="Hvilke vedlegg skal du ettersende?"
-            value={attachmentKeys}
-            onChange={(values) => {
-              setAttachmentKeys(values);
-            }}
+            value={formData.attachments ? formData.attachments.map((attachment) => attachment.key) : []}
             size="medium"
+            onChange={(checked) => {
+              const attachments = form.attachments?.filter((attachment) => checked.includes(attachment.key));
+              updateFormData({ attachments });
+            }}
             error={errors.attachments}
           >
             {form.attachments.map((attachment) => (
-              <Checkbox
-                key={attachment.key}
-                value={attachment.key}
-                name={attachment.key}
-                onChange={(e) => {
-                  const attachments = e.target.checked
-                    ? [...(formData.attachments ?? []), attachment]
-                    : formData.attachments?.filter((a) => a.key !== attachment.key);
-                  updateFormData({ attachments });
-                }}
-              >
+              <Checkbox key={attachment.key} value={attachment.key} name={attachment.key}>
                 {attachment.label}
               </Checkbox>
             ))}

--- a/src/data/appState.tsx
+++ b/src/data/appState.tsx
@@ -69,7 +69,7 @@ export function FormDataProvider({ children }: Props) {
   const resetFormData = (formData?: FormData) => {
     setValidateState(false);
     if (formData) {
-      setFormData(formData);
+      setFormData({ ...formData, attachments: [] });
     } else {
       setFormData({});
     }


### PR DESCRIPTION
[Trello](https://trello.com/c/aLlQ7Ntf/1308-valg-av-vedlegg-i-ett-skjema-smitter-over-i-andre-skjema)

## Description
- Reenabled the reset-test
- Removed `attachmentKeys` in favor of using only `formData` directly
- Explicitly clear attachments on reset

## DoD
Going from one schema to another won't "remember" the state of the previous