### PR TITLE
Varoious fixes for frontePage-generation

### DIFF
--- a/public/locales/en/last-ned.json
+++ b/public/locales/en/last-ned.json
@@ -24,7 +24,7 @@
     "download-cover-page": "Download cover sheet"
   },
   "cover-page-title": {
-    "ettersendelse": "Additional documentation for {{formNumber}} {{title}}{{extraInfo}}",
+    "ettersendelse": "Additional documentation for {{formNumber}} {{title}}",
     "innsendelse": "Submission regarding: {{titleOfSubmission}}{{extraInfo}}"
   }
 }

--- a/public/locales/nb/last-ned.json
+++ b/public/locales/nb/last-ned.json
@@ -24,7 +24,7 @@
     "download-cover-page": "Last ned førsteside"
   },
   "cover-page-title": {
-    "ettersendelse": "Ettersending til {{formNumber}} {{title}}{{extraInfo}}",
+    "ettersendelse": "Ettersending til {{formNumber}} {{title}}",
     "innsendelse": "Innsendingen gjelder: {{titleOfSubmission}}{{extraInfo}}"
   }
 }

--- a/public/locales/nn/last-ned.json
+++ b/public/locales/nn/last-ned.json
@@ -24,7 +24,7 @@
     "download-cover-page": "Last ned førsteside"
   },
   "cover-page-title": {
-    "ettersendelse": "Ettersending til {{formNumber}} {{title}}{{extraInfo}}",
+    "ettersendelse": "Ettersending til {{formNumber}} {{title}}",
     "innsendelse": "Innsendinga gjeld: {{titleOfSubmission}}{{extraInfo}}"
   }
 }

--- a/src/api/frontPageService.ts
+++ b/src/api/frontPageService.ts
@@ -24,14 +24,17 @@ const toSpraakkode = (acceptLanguage: string | undefined): string => {
 const toFrontPageRequest = (body: DownloadCoverPageRequestBody, spraakkode: string): FrontPageRequest => {
   const { formData, title } = body;
   return {
-    foerstesidetype: 'ETTERSENDELSE',
+    foerstesidetype: formData.formNumber ? 'ETTERSENDELSE' : 'LOESPOST',
     navSkjemaId: formData.formNumber || '',
     spraakkode,
     overskriftstittel: title,
-    arkivtittel: title,
+    arkivtittel: toArchiveTitle(formData),
     tema: formData.subjectOfSubmission,
     vedleggsliste: formData.attachments?.map((attachment) => attachment.attachmentTitle) ?? [],
-    dokumentlisteFoersteside: formData.attachments?.map((attachment) => attachment.label) ?? [],
+    dokumentlisteFoersteside:
+      formData.attachments?.map((attachment) =>
+        attachment.otherDocumentation ? formData.otherDocumentationTitle! : attachment.label,
+      ) ?? [],
     adresse: toFrontPageAddress(formData),
     bruker: toFrontPageUser(formData),
     ukjentBrukerPersoninfo: toUnknownAddressInfo(formData),
@@ -67,6 +70,16 @@ const toUnknownAddressInfo = (formData: FormData): string | undefined => {
       `${formData.userData?.postalCode} ${formData.userData?.city}, ` +
       `${formData.userData?.country}.`
     );
+  }
+};
+
+// Arkivtittel må være på bokmål
+const toArchiveTitle = (formData: FormData) => {
+  const { formNumber, title, titleOfSubmission, otherDocumentationTitle } = formData;
+  if (formNumber) {
+    return `Ettersending til ${formNumber} ${title}`;
+  } else {
+    return `${titleOfSubmission} - ${otherDocumentationTitle}`;
   }
 };
 

--- a/src/utils/lastNedUtil.ts
+++ b/src/utils/lastNedUtil.ts
@@ -8,7 +8,6 @@ const getCoverPageTitle = (formData: FormData, t: TFunction) => {
     return t('cover-page-title.ettersendelse', {
       formNumber,
       title,
-      extraInfo,
     });
   } else {
     return t('cover-page-title.innsendelse', {


### PR DESCRIPTION
- Removed otherDocumentationTitle from coverPageTitle for ettersending
- Changed title for otherDocumentation attachements from label to otherDocumentationTitle
- Changed foerstesidetype from 'ETTERSENDELSE' to 'LOESPOST' when formNumber is undefined
- Changed arkivtittel to NO-nb (ettersending), and trimmed it (lospost)