### PR TITLE
Create ettersending with innsending-api instead of linking to send-inn-frontend

### DIFF
--- a/.env.ci.dev
+++ b/.env.ci.dev
@@ -1,2 +1,2 @@
-NEXT_PUBLIC_SENDINN_URL=https://www.intern.dev.nav.no/sendinn/opprettSoknadResource
+NEXT_PUBLIC_SENDINN_URL=https://www.intern.dev.nav.no/sendinn
 NEXT_PUBLIC_NAV_URL=https://www.intern.dev.nav.no

--- a/.env.ci.dev
+++ b/.env.ci.dev
@@ -1,2 +1,3 @@
 NEXT_PUBLIC_SENDINN_URL=https://www.intern.dev.nav.no/sendinn
 NEXT_PUBLIC_NAV_URL=https://www.intern.dev.nav.no
+NEXT_PUBLIC_FYLLUT_FRONTEND_URL=https://fyllut-preprod.intern.dev.nav.no/fyllut

--- a/.env.ci.dev
+++ b/.env.ci.dev
@@ -1,3 +1,3 @@
-NEXT_PUBLIC_SENDINN_URL=https://www.intern.dev.nav.no/sendinn
 NEXT_PUBLIC_NAV_URL=https://www.intern.dev.nav.no
 NEXT_PUBLIC_FYLLUT_FRONTEND_URL=https://fyllut-preprod.intern.dev.nav.no/fyllut
+NEXT_PUBLIC_SEND_INN_FRONTEND_URL=https://www.intern.dev.nav.no/sendinn

--- a/.env.ci.prod
+++ b/.env.ci.prod
@@ -1,2 +1,3 @@
 NEXT_PUBLIC_SENDINN_URL=https://www.nav.no/sendinn
 NEXT_PUBLIC_NAV_URL=https://www.nav.no
+NEXT_PUBLIC_FYLLUT_FRONTEND_URL=https://nav.no/fyllut

--- a/.env.ci.prod
+++ b/.env.ci.prod
@@ -1,3 +1,3 @@
-NEXT_PUBLIC_SENDINN_URL=https://www.nav.no/sendinn
 NEXT_PUBLIC_NAV_URL=https://www.nav.no
 NEXT_PUBLIC_FYLLUT_FRONTEND_URL=https://nav.no/fyllut
+NEXT_PUBLIC_SEND_INN_FRONTEND_URL=https://www.nav.no/sendinn

--- a/.env.ci.prod
+++ b/.env.ci.prod
@@ -1,2 +1,2 @@
-NEXT_PUBLIC_SENDINN_URL=https://www.nav.no/sendinn/opprettSoknadResource
+NEXT_PUBLIC_SENDINN_URL=https://www.nav.no/sendinn
 NEXT_PUBLIC_NAV_URL=https://www.nav.no

--- a/.env.test
+++ b/.env.test
@@ -1,4 +1,4 @@
-NEXT_PUBLIC_SENDINN_URL=https://www.test.no/sendinn/opprettSoknadResource
+NEXT_PUBLIC_SENDINN_URL=https://www.test.no/sendinn
 NEXT_PUBLIC_NAV_URL=https://www.nav.no
 INNSENDING_API_URL=http://127.0.0.1:3200
 SEND_INN_FRONTEND_URL=http://127.0.0.1:3200/send-inn-frontend

--- a/.env.test
+++ b/.env.test
@@ -1,7 +1,6 @@
-NEXT_PUBLIC_SENDINN_URL=https://www.test.no/sendinn
 NEXT_PUBLIC_NAV_URL=https://www.nav.no
 INNSENDING_API_URL=http://127.0.0.1:3200
-SEND_INN_FRONTEND_URL=http://127.0.0.1:3200/send-inn-frontend
+NEXT_PUBLIC_SEND_INN_FRONTEND_URL=http://127.0.0.1:3200/send-inn-frontend
 MIN_SIDE_FRONTEND_URL=http://127.0.0.1:3200/min-side-frontend
 FYLLUT_BASE_URL=http://127.0.0.1:3200/fyllut
 APP_ENV=test

--- a/.nais/dev.yaml
+++ b/.nais/dev.yaml
@@ -17,8 +17,6 @@ env:
     value: 'dev-gcp:team-soknad:innsending-api'
   - name: INNSENDING_API_URL
     value: 'http://innsending-api.team-soknad'
-  - name: SEND_INN_FRONTEND_URL
-    value: 'https://www.intern.dev.nav.no/sendinn'
   - name: MIN_SIDE_FRONTEND_URL
     value: 'https://www.intern.dev.nav.no/minside'
   - name: APP_ENV

--- a/.nais/prod.yaml
+++ b/.nais/prod.yaml
@@ -14,8 +14,6 @@ env:
     value: 'prod-gcp:team-soknad:innsending-api'
   - name: INNSENDING_API_URL
     value: 'http://innsending-api.team-soknad'
-  - name: SEND_INN_FRONTEND_URL
-    value: 'https://www.nav.no/sendinn'
   - name: MIN_SIDE_FRONTEND_URL
     value: 'https://www.nav.no/minside'
   - name: APP_ENV

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Man kan utvikle lokalt uten å være avhengig av eksterne api'er ved å kjøre o
 URLer i `.env.local` må peke til mock:
 
     INNSENDING_API_URL=http://127.0.0.1:3200
-    SEND_INN_FRONTEND_URL=http://127.0.0.1:3200/send-inn-frontend
+    NEXT_PUBLIC_SEND_INN_FRONTEND_URL=http://127.0.0.1:3200/send-inn-frontend
     MIN_SIDE_FRONTEND_URL=http://127.0.0.1:3200/min-side-frontend
     FYLLUT_BASE_URL=http://127.0.0.1:3200/fyllut
 

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -22,6 +22,7 @@ export default defineConfig({
       SEND_INN_FRONTEND_URL: 'http://127.0.0.1:3200/send-inn-frontend',
       MIN_SIDE_FRONTEND_URL: 'http://127.0.0.1:3200/min-side-frontend',
       FYLLUT_BASE_URL: 'http://127.0.0.1:3200/fyllut',
+      NEXT_PUBLIC_FYLLUT_FRONTEND_URL: 'http://127.0.0.1:3200/fyllut-frontend',
     },
   },
 });

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -19,7 +19,7 @@ export default defineConfig({
     setupNodeEvents(on, config) {},
     env: {
       INNSENDING_API_URL: 'http://127.0.0.1:3200',
-      SEND_INN_FRONTEND_URL: 'http://127.0.0.1:3200/send-inn-frontend',
+      NEXT_PUBLIC_SEND_INN_FRONTEND_URL: 'http://127.0.0.1:3200/send-inn-frontend',
       MIN_SIDE_FRONTEND_URL: 'http://127.0.0.1:3200/min-side-frontend',
       FYLLUT_BASE_URL: 'http://127.0.0.1:3200/fyllut',
       NEXT_PUBLIC_FYLLUT_FRONTEND_URL: 'http://127.0.0.1:3200/fyllut-frontend',

--- a/cypress/e2e/digitalSubmission.spec.cy.ts
+++ b/cypress/e2e/digitalSubmission.spec.cy.ts
@@ -47,7 +47,7 @@ describe('digital submission for form2', () => {
 
     cy.wait('@postEttersending');
 
-    cy.url().should('include', `/sendinn/${innsendingsId}`);
+    cy.url().should('include', `/send-inn-frontend/${innsendingsId}`);
   });
 
   it('should show error message when request fails', () => {
@@ -64,7 +64,7 @@ describe('digital submission for form2', () => {
 
     cy.wait('@postEttersending');
 
-    cy.url().should('not.include', `/sendinn/${innsendingsId}`);
+    cy.url().should('not.include', `/send-inn-frontend/${innsendingsId}`);
     cy.findByText('Det oppstod en feil ved ettersending av dokumentasjon').should('be.visible');
   });
 });

--- a/cypress/e2e/digitalSubmission.spec.cy.ts
+++ b/cypress/e2e/digitalSubmission.spec.cy.ts
@@ -1,0 +1,70 @@
+import FORM2 from '../../mocks/data/fyllut/form2.json';
+import { EttersendingRequestBody } from '../../src/data/domain';
+import { TestButtonText } from './testUtils';
+
+beforeEach(() => {
+  cy.mocksRestoreRouteVariants();
+});
+afterEach(() => {
+  cy.mocksRestoreRouteVariants();
+});
+
+// InnsendingsId from the backend (ettersending.json)
+const innsendingsId = 'bd86463d-ad04-43e8-a80a-9ecd22bae7c0';
+
+const n6 = FORM2.attachments.find((a) => a.attachmentCode === 'N6');
+const l9 = FORM2.attachments.find((a) => a.attachmentCode === 'L9');
+
+describe('digital submission for form2', () => {
+  beforeEach(() => {
+    cy.intercept('POST', `${Cypress.config('baseUrl')}/api/ettersending`, (req) => {
+      const body = req.body as EttersendingRequestBody;
+
+      expect(body.tittel).to.equal(FORM2.title);
+      expect(body.skjemanr).to.equal(FORM2.properties.skjemanummer);
+      expect(body.tema).to.equal(FORM2.properties.tema);
+      expect(body.sprak).to.equal('nb');
+      expect(body.vedleggsListe.length).to.equal(2);
+
+      const l9Body = body.vedleggsListe.find((v) => v.vedleggsnr === 'L9');
+      expect(l9Body?.tittel).to.equal(l9?.label);
+
+      const n6Body = body.vedleggsListe.find((v) => v.vedleggsnr === 'N6');
+      expect(n6Body?.tittel).to.equal(n6?.label);
+    }).as('postEttersending');
+  });
+
+  it('should create ettersending with expected data and redirect to sendinn', () => {
+    cy.mocksUseRouteVariant('post-ettersending:success');
+    cy.visit('/form2?sub=digital');
+
+    // Choose attachments
+    cy.findByRole('checkbox', { name: n6?.label }).check();
+    cy.findByRole('checkbox', { name: l9?.label }).check();
+
+    // Click next
+    cy.get('button').contains(TestButtonText.next).click();
+
+    cy.wait('@postEttersending');
+
+    cy.url().should('include', `/sendinn/${innsendingsId}`);
+  });
+
+  it('should show error message when request fails', () => {
+    cy.mocksUseRouteVariant('post-ettersending:failure');
+
+    cy.visit('/form2?sub=digital');
+
+    // Choose attachments
+    cy.findByRole('checkbox', { name: n6?.label }).check();
+    cy.findByRole('checkbox', { name: l9?.label }).check();
+
+    // Click next
+    cy.get('button').contains(TestButtonText.next).click();
+
+    cy.wait('@postEttersending');
+
+    cy.url().should('not.include', `/sendinn/${innsendingsId}`);
+    cy.findByText('Det oppstod en feil ved ettersending av dokumentasjon').should('be.visible');
+  });
+});

--- a/cypress/e2e/formDetail.spec.cy.ts
+++ b/cypress/e2e/formDetail.spec.cy.ts
@@ -15,7 +15,10 @@ describe('redirects correctly based on existing ettersendelse applications', () 
   it('should redirect to send-inn with 1 application', () => {
     cy.mocksUseRouteVariant('get-ettersendingssoknader:one');
     cy.visit('/form2?sub=digital');
-    cy.url().should('equal', `${Cypress.env('SEND_INN_FRONTEND_URL')}/bd86463d-ad04-43e8-a80a-9ecd22bae7c0/`);
+    cy.url().should(
+      'equal',
+      `${Cypress.env('NEXT_PUBLIC_SEND_INN_FRONTEND_URL')}/bd86463d-ad04-43e8-a80a-9ecd22bae7c0/`,
+    );
   });
 
   it('should redirect to min-side varsler with 2 or more applications', () => {

--- a/cypress/e2e/sendPreviouslySubmittedApplication.spec.cy.ts
+++ b/cypress/e2e/sendPreviouslySubmittedApplication.spec.cy.ts
@@ -95,7 +95,7 @@ describe('sendPreviouslySubmittedApplication', () => {
     cy.findByRole('checkbox', { name: 'Legeerklæring om alminnelig helsetilstand' }).check();
     cy.findByRole('checkbox', { name: 'Annen dokumentasjon' }).check();
     cy.get('button').contains(TestButtonText.next).click();
-    cy.url().should('include', '/sendinn/bd86463d-ad04-43e8-a80a-9ecd22bae7c0');
+    cy.url().should('include', '/send-inn-frontend/bd86463d-ad04-43e8-a80a-9ecd22bae7c0');
   });
 
   it('fill out + submit, should not redirect to subType-page', () => {

--- a/cypress/e2e/sendPreviouslySubmittedApplication.spec.cy.ts
+++ b/cypress/e2e/sendPreviouslySubmittedApplication.spec.cy.ts
@@ -95,9 +95,7 @@ describe('sendPreviouslySubmittedApplication', () => {
     cy.findByRole('checkbox', { name: 'Legeerklæring om alminnelig helsetilstand' }).check();
     cy.findByRole('checkbox', { name: 'Annen dokumentasjon' }).check();
     cy.get('button').contains(TestButtonText.next).click();
-    cy.url().should('include', '/sendinn/opprettSoknadResource?erEttersendelse=true');
-    cy.url({ decode: true }).should('include', 'skjemanummer=NAV 10-07.50');
-    cy.url().should('include', 'vedleggsIder=N6,L9');
+    cy.url().should('include', '/sendinn/bd86463d-ad04-43e8-a80a-9ecd22bae7c0');
   });
 
   it('fill out + submit, should not redirect to subType-page', () => {

--- a/cypress/tsconfig.json
+++ b/cypress/tsconfig.json
@@ -5,7 +5,10 @@
     "types": ["cypress", "@testing-library/cypress", "node"],
     "allowJs": false,
     "strict": true,
-    "jsx": "preserve"
+    "jsx": "preserve",
+    "resolveJsonModule": true,
+    "esModuleInterop": true,
+
   },
   "include": ["**/*.ts"]
 }

--- a/mocks/collections.json
+++ b/mocks/collections.json
@@ -10,7 +10,8 @@
       "get-nav-units:all",
       "get-form-1:success",
       "get-form-2:success",
-      "get-form-3:success"
+      "get-form-3:success",
+      "post-ettersending:success"
     ]
   }
 ]

--- a/mocks/data/fyllut-frontend/index.html
+++ b/mocks/data/fyllut-frontend/index.html
@@ -1,0 +1,5 @@
+<html>
+    <body>
+        <h1>Fyllut frontend</h1>
+    </body>
+</html>

--- a/mocks/routes/innsending-api.js
+++ b/mocks/routes/innsending-api.js
@@ -1,5 +1,11 @@
 const exampleEttersending = require('../data/ettersending.json');
 
+const errorResponse = {
+  message: 'Something went wrong, try again later',
+  timestamp: '2024-01-08T12:38:25.645477+01:00',
+  errorCode: 'somethingFailedTryLater',
+};
+
 module.exports = [
   {
     id: 'get-ettersendingssoknader',
@@ -28,6 +34,29 @@ module.exports = [
         options: {
           status: 200,
           body: [exampleEttersending, exampleEttersending],
+        },
+      },
+    ],
+  },
+  {
+    id: 'post-ettersending',
+    url: '/fyllut/v1/ettersending',
+    method: 'POST',
+    variants: [
+      {
+        id: 'success',
+        type: 'json',
+        options: {
+          status: 200,
+          body: exampleEttersending,
+        },
+      },
+      {
+        id: 'failure',
+        type: 'json',
+        options: {
+          status: 500,
+          body: errorResponse,
         },
       },
     ],

--- a/public/locales/en/detaljer.json
+++ b/public/locales/en/detaljer.json
@@ -6,5 +6,6 @@
     "legend": "Which documents do you wish to submit?",
     "other-documentation-label": "Give the document a descriptive name"
   },
-  "no-attachments-alert": "This form has no attachments"
+  "no-attachments-alert": "This form has no attachments",
+  "ettersending-error": "An error occurred while sending in the form"
 }

--- a/public/locales/nb/detaljer.json
+++ b/public/locales/nb/detaljer.json
@@ -6,5 +6,6 @@
     "legend": "Hvilke dokumenter skal du ettersende?",
     "other-documentation-label": "Gi dokumentet et beskrivende navn"
   },
-  "no-attachments-alert": "Dette skjemaet har ingen vedlegg"
+  "no-attachments-alert": "Dette skjemaet har ingen vedlegg",
+  "ettersending-error": "Det oppstod en feil ved ettersending av dokumentasjon"
 }

--- a/public/locales/nn/detaljer.json
+++ b/public/locales/nn/detaljer.json
@@ -6,5 +6,6 @@
     "legend": "Kva dokument skal du ettersenda?",
     "other-documentation-label": "Gje dokumentet eit beskrivande namn"
   },
-  "no-attachments-alert": "Dette skjemaet har ingen vedlegg"
+  "no-attachments-alert": "Dette skjemaet har ingen vedlegg",
+  "ettersending-error": "Det oppstod en feil ved ettersending av dokumentasjon"
 }

--- a/public/locales/nn/detaljer.json
+++ b/public/locales/nn/detaljer.json
@@ -7,5 +7,5 @@
     "other-documentation-label": "Gje dokumentet eit beskrivande namn"
   },
   "no-attachments-alert": "Dette skjemaet har ingen vedlegg",
-  "ettersending-error": "Det oppstod en feil ved ettersending av dokumentasjon"
+  "ettersending-error": "Det oppstod ein feil ved ettersending av dokumentasjon"
 }

--- a/src/api/apiClient.ts
+++ b/src/api/apiClient.ts
@@ -1,11 +1,11 @@
 import FileSaver from 'file-saver';
 import {
-  ApiError,
   DownloadCoverPageRequestBody,
   EttersendelseApplication,
   EttersendingRequestBody,
   EttersendingVedlegg,
   FormData,
+  HttpError,
   KeyValue,
   NavUnit,
 } from '../data/domain';
@@ -44,7 +44,7 @@ const downloadFrontpage = async (formData: FormData, title: string, lang: string
   FileSaver.saveAs(await b64.blob(), getFileName(formData));
 };
 
-const createEttersending = async (formData: FormData) => {
+const createEttersending = async (formData: FormData): Promise<EttersendelseApplication> => {
   const jsonBody: EttersendingRequestBody = {
     tittel: formData.title,
     skjemanr: formData.formNumber!,
@@ -69,10 +69,10 @@ const createEttersending = async (formData: FormData) => {
   });
 
   if (!result.ok) {
-    throw new ApiError('ettersending-error');
+    throw new HttpError(result.statusText, result.status);
   }
 
-  const resultJson = (await result.json()) as EttersendelseApplication;
+  const resultJson = await result.json();
   return resultJson;
 };
 

--- a/src/api/apiClient.ts
+++ b/src/api/apiClient.ts
@@ -55,7 +55,9 @@ const createEttersending = async (formData: FormData): Promise<EttersendelseAppl
         return {
           vedleggsnr: attachment.attachmentCode,
           tittel: attachment.label,
-          url: attachment.attachmentForm ? `${process.env.FYLLUT_BASE_URL}/${attachment.attachmentForm}` : undefined,
+          url: attachment.attachmentForm
+            ? `${process.env.NEXT_PUBLIC_FYLLUT_FRONTEND_URL}/${attachment.attachmentForm}`
+            : undefined,
         };
       }) ?? [],
   };

--- a/src/api/apiClient.ts
+++ b/src/api/apiClient.ts
@@ -56,7 +56,7 @@ const createEttersending = async (formData: FormData): Promise<EttersendelseAppl
           vedleggsnr: attachment.attachmentCode,
           tittel: attachment.label,
           url: attachment.attachmentForm
-            ? `${process.env.NEXT_PUBLIC_FYLLUT_FRONTEND_URL}/${attachment.attachmentForm}`
+            ? `${process.env.NEXT_PUBLIC_FYLLUT_FRONTEND_URL}/${attachment.attachmentForm}?sub=paper`
             : undefined,
         };
       }) ?? [],

--- a/src/api/apiService.ts
+++ b/src/api/apiService.ts
@@ -41,16 +41,15 @@ const getForms = async (): Promise<BasicForm[]> => {
 
 const getForm = async (formPath: string, language: string = 'nb'): Promise<Form | undefined> => {
   const startTime = Date.now();
-  let form: FyllutForm | undefined;
+  let form: FyllutForm;
 
   try {
     form = await get<FyllutForm>(`${process.env.FYLLUT_BASE_URL}/api/forms/${formPath}?type=limited&lang=${language}`);
     logger.debug(`Load form ${formPath} (ms: ${Date.now() - startTime})`);
   } catch (e) {
     logger.error(`Failed to load form ${formPath}`, e as Error);
+    return undefined;
   }
-
-  if (!form) return undefined;
 
   const sortedAttachments = form.attachments.sort((a: Attachment, b: Attachment) => {
     if (b.otherDocumentation) {

--- a/src/api/apiService.ts
+++ b/src/api/apiService.ts
@@ -127,7 +127,7 @@ const getEttersendinger = async (idportenToken: string, id: string) => {
   try {
     const tokenxToken = await getTokenX(idportenToken);
 
-    const response = await get(
+    const response = await get<EttersendelseApplication[]>(
       `${process.env.INNSENDING_API_URL}/frontend/v1/skjema/${id}/soknader?soknadstyper=ettersendelse`,
       { Authorization: `Bearer ${tokenxToken}` },
     );
@@ -145,9 +145,7 @@ const createEttersending = async (idportenToken: string, ettersendingBody: Etter
   const response = await post<EttersendelseApplication>(
     `${process.env.INNSENDING_API_URL}/fyllut/v1/ettersending`,
     ettersendingBody,
-    {
-      Authorization: `Bearer ${tokenxToken}`,
-    },
+    { Authorization: `Bearer ${tokenxToken}` },
   );
 
   return response;

--- a/src/api/apiService.ts
+++ b/src/api/apiService.ts
@@ -132,20 +132,16 @@ const getEttersendinger = async (idportenToken: string, id: string) => {
 };
 
 const createEttersending = async (idportenToken: string, ettersendingBody: EttersendingRequestBody) => {
-  try {
-    const tokenxToken = await getTokenX(idportenToken);
+  const tokenxToken = await getTokenX(idportenToken);
 
-    const response = await post(
-      `${process.env.INNSENDING_API_URL}/fyllut/v1/ettersending`,
-      JSON.stringify(ettersendingBody),
-      { Authorization: `Bearer ${tokenxToken}` },
-    );
+  const response = await post(
+    `${process.env.INNSENDING_API_URL}/fyllut/v1/ettersending`,
+    JSON.stringify(ettersendingBody),
+    { Authorization: `Bearer ${tokenxToken}` },
+    true,
+  );
 
-    return response;
-  } catch (e) {
-    logger.error('Could not create ettersending', e as Error);
-    return [];
-  }
+  return response;
 };
 
 const getTokenX = async (idportenToken: string) => {

--- a/src/api/frontPageService.ts
+++ b/src/api/frontPageService.ts
@@ -7,7 +7,7 @@ const download = async (body: DownloadCoverPageRequestBody, acceptLanguage: stri
   try {
     const spraakkode = toSpraakkode(acceptLanguage);
     pdf = await downloadFrontPage(toFrontPageRequest(body, spraakkode));
-    return Buffer.from(pdf.foersteside, 'base64');
+    return Buffer.from(pdf?.foersteside ?? '', 'base64');
   } catch (e) {
     logger.error('Failed to download front page', e);
   }

--- a/src/api/http.ts
+++ b/src/api/http.ts
@@ -31,12 +31,19 @@ const get = async (url: string, headers?: HttpHeaders) => {
   return handleResponse(response, url);
 };
 
-const post = async (url: string, body: BodyInit, headers?: HttpHeaders) => {
+const post = async (
+  url: string,
+  body: BodyInit,
+  headers?: HttpHeaders,
+  returnResponse: boolean = false,
+): Promise<Response> => {
   const response = await fetch(url, {
     method: 'POST',
     headers: getDefaultHeaders(headers),
     body,
   });
+
+  if (returnResponse) return response;
 
   return handleResponse(response, url);
 };

--- a/src/api/loginRedirect.ts
+++ b/src/api/loginRedirect.ts
@@ -20,7 +20,7 @@ const getIdPortenToken = async (authHeader?: string, sub?: string | string[] | u
     try {
       await verifyIdportenAccessToken(idportenToken);
     } catch (e) {
-      logger.info('Could not validate idporten token');
+      logger.warn('Could not validate idporten token', e);
       throw new UnauthenticatedError('Could not validate idporten token');
     }
     return idportenToken;

--- a/src/api/loginRedirect.ts
+++ b/src/api/loginRedirect.ts
@@ -4,10 +4,14 @@ import { SubmissionType, UnauthenticatedError } from 'src/data/domain';
 import { isLocalDevelopment } from 'src/utils/utils';
 import logger from '../utils/logger';
 
-const getIdPortenToken = async (context: GetServerSidePropsContext) => {
+const getIdPortenTokenFromContext = async (context: GetServerSidePropsContext) => {
   const sub = context.query?.sub;
   const authHeader = context.req.headers.authorization;
 
+  return getIdPortenToken(authHeader, sub);
+};
+
+const getIdPortenToken = async (authHeader?: string, sub?: string | string[] | undefined) => {
   if (isLocalDevelopment()) {
     logger.info('Mocking idporten jwt and pid');
     return 'mock-idporten-token';
@@ -26,4 +30,4 @@ const getIdPortenToken = async (context: GetServerSidePropsContext) => {
   }
 };
 
-export { getIdPortenToken };
+export { getIdPortenToken, getIdPortenTokenFromContext };

--- a/src/components/button/buttonGroupElement.tsx
+++ b/src/components/button/buttonGroupElement.tsx
@@ -35,7 +35,7 @@ const ButtonGroupElement = ({ type }: Props) => {
     }
 
     if (onClick) {
-      onClick(e);
+      await onClick(e);
     } else if (path) {
       if (external) {
         window.location.href = path;

--- a/src/data/domain.ts
+++ b/src/data/domain.ts
@@ -101,6 +101,20 @@ export interface DownloadCoverPageRequestBody {
   title: string;
 }
 
+export interface EttersendingRequestBody {
+  tittel?: string;
+  skjemanr: string;
+  sprak: string;
+  tema: string;
+  vedleggsListe: EttersendingVedlegg[];
+}
+
+export interface EttersendingVedlegg {
+  vedleggsnr: string;
+  tittel?: string;
+  url?: string;
+}
+
 export enum SubmissionType {
   digital = 'digital',
   paper = 'paper',

--- a/src/data/domain.ts
+++ b/src/data/domain.ts
@@ -1,5 +1,6 @@
 export class UnauthenticatedError extends Error {}
-
+export class ApiError extends Error {}
+export const isApiError = (err: unknown): err is ApiError => err instanceof ApiError;
 export interface BasicForm {
   _id: string;
   modified: string;
@@ -38,6 +39,7 @@ export interface Attachment {
   otherDocumentation: boolean;
   attachmentTitle: string;
   attachmentCode: string;
+  attachmentForm?: string;
 }
 
 export type AllowedSubmissionType = 'PAPIR_OG_DIGITAL' | 'KUN_PAPIR' | 'KUN_DIGITAL' | 'INGEN';

--- a/src/data/domain.ts
+++ b/src/data/domain.ts
@@ -1,6 +1,13 @@
 export class UnauthenticatedError extends Error {}
-export class ApiError extends Error {}
-export const isApiError = (err: unknown): err is ApiError => err instanceof ApiError;
+export const isHttpError = (err: unknown): err is HttpError => err instanceof HttpError;
+export class HttpError extends Error {
+  public readonly status: number;
+
+  constructor(message: string, status: number) {
+    super(message);
+    this.status = status;
+  }
+}
 export interface BasicForm {
   _id: string;
   modified: string;
@@ -16,6 +23,24 @@ export interface FyllutListFormProperties {
   skjemanummer?: string;
   innsending?: AllowedSubmissionType;
   ettersending?: AllowedSubmissionType;
+}
+
+export interface FyllutFoerstesidePdf {
+  foersteside: string; // Base64
+}
+
+export interface FyllytFormProperties {
+  skjemanummer?: string;
+  tema: string;
+  innsending?: AllowedSubmissionType;
+  ettersending?: AllowedSubmissionType;
+  enhetstyper?: string[];
+  enhetMaVelgesVedPapirInnsending?: boolean;
+}
+
+export interface FyllutForm extends BasicForm {
+  properties: FyllytFormProperties;
+  attachments: Attachment[];
 }
 
 // For the FormSearch component

--- a/src/pages/[id]/index.tsx
+++ b/src/pages/[id]/index.tsx
@@ -8,10 +8,10 @@ import { useRouter } from 'next/router';
 import { GetServerSidePropsContext } from 'next/types';
 import { useCallback, useEffect, useState } from 'react';
 import { getEttersendinger, getForm } from 'src/api/apiService';
-import { getIdPortenToken } from 'src/api/loginRedirect';
+import { getIdPortenTokenFromContext } from 'src/api/loginRedirect';
 import ValidationSummary from 'src/components/validationSummary/validationSummary';
 import { useReffererPage } from 'src/hooks/useReferrerPage';
-import { fetchNavUnits } from '../../api/apiClient';
+import { createEttersending, fetchNavUnits } from '../../api/apiClient';
 import ChooseAttachments from '../../components/attachment/chooseAttachments';
 import ButtonGroup from '../../components/button/buttonGroup';
 import { ButtonType } from '../../components/button/buttonGroupElement';
@@ -24,7 +24,6 @@ import { Paths } from '../../data/paths';
 import { getServerSideTranslations, localePathPrefix } from '../../utils/i18nUtil';
 import {
   areBothSubmissionTypesAllowed,
-  createSubmissionUrl,
   getDefaultSubmissionType,
   isSubmissionAllowed,
   isSubmissionTypePaper,
@@ -89,7 +88,7 @@ const Detaljer: NextPage<Props> = (props) => {
   const submitButton: ButtonType = {
     text: tCommon('button.next'),
     external: true,
-    path: createSubmissionUrl(form, formData),
+    onClick: async () => await createEttersending(formData),
     validateForm: true,
     icon: <ArrowRightIcon aria-hidden />,
     iconPosition: 'right',
@@ -125,6 +124,7 @@ const Detaljer: NextPage<Props> = (props) => {
                 shouldRenderNavUnits={form.properties.navUnitMustBeSelected}
               />
             )}
+
             <ButtonGroup
               buttons={[
                 formData.submissionType === SubmissionType.digital ? submitButton : downloadButton,
@@ -159,7 +159,7 @@ export async function getServerSideProps(context: GetServerSidePropsContext) {
   // Attempt to verify the token and redirect to login if necessary
   let idportenToken = '';
   try {
-    idportenToken = (await getIdPortenToken(context)) as string;
+    idportenToken = (await getIdPortenTokenFromContext(context)) as string;
   } catch (ex) {
     if (ex instanceof UnauthenticatedError) {
       return redirectToLogin(context);

--- a/src/pages/[id]/index.tsx
+++ b/src/pages/[id]/index.tsx
@@ -19,14 +19,7 @@ import Layout from '../../components/layout/layout';
 import Section from '../../components/section/section';
 import ChooseUser from '../../components/submission/chooseUser';
 import { useFormState } from '../../data/appState';
-import {
-  EttersendelseApplication,
-  Form,
-  NavUnit,
-  SubmissionType,
-  UnauthenticatedError,
-  isApiError,
-} from '../../data/domain';
+import { EttersendelseApplication, Form, NavUnit, SubmissionType, UnauthenticatedError } from '../../data/domain';
 import { Paths } from '../../data/paths';
 import { getServerSideTranslations, localePathPrefix } from '../../utils/i18nUtil';
 import {
@@ -74,9 +67,7 @@ const Detaljer: NextPage<Props> = (props) => {
       const ettersending = await createEttersending(formData);
       router.push(`${process.env.NEXT_PUBLIC_SENDINN_URL}/${ettersending.innsendingsId}`);
     } catch (error) {
-      if (isApiError(error)) {
-        setErrorMessage(t(error.message));
-      }
+      setErrorMessage(t('ettersending-error'));
     }
   };
 

--- a/src/pages/[id]/index.tsx
+++ b/src/pages/[id]/index.tsx
@@ -65,7 +65,7 @@ const Detaljer: NextPage<Props> = (props) => {
   const submitButtonPressed = async () => {
     try {
       const ettersending = await createEttersending(formData);
-      router.push(`${process.env.NEXT_PUBLIC_SENDINN_URL}/${ettersending.innsendingsId}`);
+      router.push(`${process.env.NEXT_PUBLIC_SEND_INN_FRONTEND_URL}/${ettersending.innsendingsId}`);
     } catch (error) {
       setErrorMessage(t('ettersending-error'));
     }
@@ -217,7 +217,10 @@ const redirectBasedOnExistingEttersendinger = (
   res: ServerResponse,
 ) => {
   if (existingEttersendinger.length === 1) {
-    res.setHeader('Location', `${process.env.SEND_INN_FRONTEND_URL}/${existingEttersendinger[0].innsendingsId}`);
+    res.setHeader(
+      'Location',
+      `${process.env.NEXT_PUBLIC_SEND_INN_FRONTEND_URL}/${existingEttersendinger[0].innsendingsId}`,
+    );
     res.statusCode = 302;
   }
 

--- a/src/pages/api/ettersending/index.ts
+++ b/src/pages/api/ettersending/index.ts
@@ -1,0 +1,17 @@
+import { NextApiRequest, NextApiResponse } from 'next';
+import { createEttersending } from 'src/api/apiService';
+import { getIdPortenToken } from 'src/api/loginRedirect';
+import { EttersendingRequestBody } from '../../../data/domain';
+
+const handler = async (req: NextApiRequest, res: NextApiResponse) => {
+  if (req.method === 'POST') {
+    const body: EttersendingRequestBody = req.body;
+    const idportenToken = (await getIdPortenToken(req.headers.authorization)) as string;
+
+    // FIXME: Send correct status code
+    res.status(200);
+    res.send(await createEttersending(idportenToken, body));
+  }
+};
+
+export default handler;

--- a/src/pages/api/ettersending/index.ts
+++ b/src/pages/api/ettersending/index.ts
@@ -1,16 +1,27 @@
 import { NextApiRequest, NextApiResponse } from 'next';
 import { createEttersending } from 'src/api/apiService';
 import { getIdPortenToken } from 'src/api/loginRedirect';
-import { EttersendingRequestBody } from '../../../data/domain';
+import { EttersendelseApplication, EttersendingRequestBody } from '../../../data/domain';
+import logger from '../../../utils/logger';
 
 const handler = async (req: NextApiRequest, res: NextApiResponse) => {
   if (req.method === 'POST') {
     const body: EttersendingRequestBody = req.body;
     const idportenToken = (await getIdPortenToken(req.headers.authorization)) as string;
 
-    // FIXME: Send correct status code
-    res.status(200);
-    res.send(await createEttersending(idportenToken, body));
+    const response = await createEttersending(idportenToken, body);
+
+    if (response.ok) {
+      const ettersending = (await response.json()) as EttersendelseApplication;
+      res.status(200);
+      res.send(ettersending);
+    } else {
+      const errorResponse = await response.json();
+      logger.error('Error creating ettersending', errorResponse);
+
+      res.status(response.status);
+      res.send(errorResponse);
+    }
   }
 };
 

--- a/src/utils/submissionUtil.ts
+++ b/src/utils/submissionUtil.ts
@@ -16,15 +16,6 @@ const getDefaultSubmissionType = (form: Form, router: NextRouter): SubmissionTyp
   return SubmissionType.paper;
 };
 
-const createSubmissionUrl = (form: Form, formData: FormData): string => {
-  const formNumber = form.properties.formNumber!;
-  const attachmentList = formData.attachments?.map(({ attachmentCode }) => attachmentCode);
-
-  return `${process.env.NEXT_PUBLIC_SENDINN_URL}?erEttersendelse=true&sprak=NO_NB&skjemanummer=${encodeURIComponent(
-    formNumber,
-  )}&vedleggsIder=${attachmentList}`;
-};
-
 const isSubmissionAllowed = (form: Form) => {
   return form.attachments?.length > 0 && form.properties.submissionType !== 'INGEN';
 };
@@ -68,7 +59,6 @@ const isValidSubmissionTypeInUrl = (form: Form, submissionType: string | undefin
 
 export {
   areBothSubmissionTypesAllowed,
-  createSubmissionUrl,
   getDefaultSubmissionType,
   isDigitalSubmissionAllowed,
   isPaperSubmissionAllowed,


### PR DESCRIPTION
https://trello.com/c/isDPnswL/1668-implementere-endepunkt-for-opprettelse-av-ettersending-frontend
https://trello.com/c/awIcaxvc/1664-ettersendelse-nav-skjemaer-som-er-vedlegg-skal-ikke-hentes-fra-sanity

Ettersendinger is now created in this application instead of linking to send-inn-frontend. This allows for:

- Sending more information instead of just the attachment codes. Now supports different titles for the same attachment code (example: two N6 attachments with different titles) 
- Detachment from Sanity in favor of using data from fyllut (skjemabyggeren). No need to get title, url etc from Sanity
